### PR TITLE
chore: downgrade bundler to 2.5.18 and update setup script

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,4 +617,4 @@ RUBY VERSION
   ruby 4.0.0
 
 BUNDLED WITH
-  4.0.3
+  2.5.18

--- a/bin/setup
+++ b/bin/setup
@@ -13,7 +13,17 @@ FileUtils.chdir APP_ROOT do
   # Add necessary setup steps to this file.
 
   puts "== Installing dependencies =="
-  system("bundle check") || system!("bundle install")
+  # Use Bundler CLI directly to avoid RubyGems path issues in Ruby 4.0.0
+  begin
+    require "bundler/cli"
+    begin
+      Bundler::CLI.start(["check"])
+    rescue StandardError
+      Bundler::CLI.start(["install"])
+    end
+  rescue LoadError
+    system("bundle check") || system!("bundle install")
+  end
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")


### PR DESCRIPTION
- Downgrade bundler version from 4.0.3 to 2.5.18 in Gemfile.lock
- Update bin/setup to use Bundler CLI directly to avoid RubyGems path issues in Ruby 4.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the setup script to improve how it checks for and installs project dependencies. The updated process includes enhanced error handling to ensure more reliable setup execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->