### PR TITLE
refactor: move cache invalidation from DramasController to Drama model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,29 +73,6 @@ jobs:
         env:
           PREBAKE_LOG_LEVEL: debug
 
-      - name: Debug bigdecimal
-        if: always()
-        run: |
-            echo "=== bigdecimal gem location ==="
-            bundle show bigdecimal
-
-            echo "=== extension dir ==="
-            bundle exec ruby -e "
-              spec = Gem::Specification.find_by_name('bigdecimal')
-              puts \"extension_dir: #{spec.extension_dir}\"
-              puts \"gem_build_complete: #{File.exist?(spec.gem_build_complete_path)}\"
-              if File.directory?(spec.extension_dir)
-                Dir.glob(File.join(spec.extension_dir, '**/*')).each do |f|
-                  puts \"  #{f} (#{File.size(f)} bytes)\"
-                end
-              else
-                puts 'extension_dir DOES NOT EXIST'
-              end
-            "
-
-            echo "=== require test ==="
-            bundle exec ruby -e "require 'bigdecimal'; puts BigDecimal(1)" 2>&1 || true
-
       - name: Run tests
         env:
           RAILS_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,31 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+        env:
+          PREBAKE_LOG_LEVEL: debug
+
+      - name: Debug bigdecimal
+        if: always()
+        run: |
+            echo "=== bigdecimal gem location ==="
+            bundle show bigdecimal
+
+            echo "=== extension dir ==="
+            bundle exec ruby -e "
+              spec = Gem::Specification.find_by_name('bigdecimal')
+              puts \"extension_dir: #{spec.extension_dir}\"
+              puts \"gem_build_complete: #{File.exist?(spec.gem_build_complete_path)}\"
+              if File.directory?(spec.extension_dir)
+                Dir.glob(File.join(spec.extension_dir, '**/*')).each do |f|
+                  puts \"  #{f} (#{File.size(f)} bytes)\"
+                end
+              else
+                puts 'extension_dir DOES NOT EXIST'
+              end
+            "
+
+            echo "=== require test ==="
+            bundle exec ruby -e "require 'bigdecimal'; puts BigDecimal(1)" 2>&1 || true
 
       - name: Run tests
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ gem "activerecord", github: "rails/rails", branch: "main"
 gem "activejob", github: "rails/rails", branch: "main"
 gem "actionpack", github: "rails/rails", branch: "main"
 
+# Required as an explicit dependency since Ruby 4.0 removed it from the standard library
+gem "bigdecimal"
+
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", ">= 2.1"
 # Use the Puma web server [https://github.com/puma/puma]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 36bf938103be3d7037b21ce2af0a6863b2341762
+  revision: 706b9daab37664710de20cca273eb9ffa5361ec3
   branch: main
   specs:
     actionpack (8.2.0.alpha)
@@ -390,7 +390,7 @@ GEM
     timeout (0.6.1)
     tsort (0.2.0)
     tty-which (0.5.0)
-    typelizer (0.11.0)
+    typelizer (0.12.0)
       benchmark
       railties (>= 6.0.0)
     tzinfo (2.0.6)
@@ -585,7 +585,7 @@ CHECKSUMS
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   tty-which (0.5.0) sha256=5824055f0d6744c97e7c4426544f01d519c40d1806ef2ef47d9854477993f466
-  typelizer (0.11.0) sha256=6f4bc70c4d4110bae8055d5fe88175f61e2da910c87fc70110f9c9fff5b5c587
+  typelizer (0.12.0) sha256=84f8f6cb9cf583e11dc3bf91a66c3e010d159cf9ec0d8d81c6908dfea3227860
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -599,4 +599,4 @@ RUBY VERSION
    ruby 4.0.1p0
 
 BUNDLED WITH
-   2.5.18
+   4.0.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,6 +420,7 @@ DEPENDENCIES
   activemodel!
   activerecord!
   alba
+  bigdecimal
   bootsnap
   brakeman
   bundler-audit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -599,4 +599,4 @@ RUBY VERSION
    ruby 4.0.1p0
 
 BUNDLED WITH
-   4.0.9
+   2.7.2

--- a/app/controllers/api/v1/dramas_controller.rb
+++ b/app/controllers/api/v1/dramas_controller.rb
@@ -1,17 +1,13 @@
 # Handles API endpoints for drama management (list, show, create, update)
 class Api::V1::DramasController < ApplicationController
-  LIST_CACHE_KEY = "drama_list"
-
-  before_action :clear_cache, only: %i[create update]
-
   def index
-    dramas = Rails.cache.fetch(LIST_CACHE_KEY, expires_in: 1.week) { Drama.in_progress_first.load }
+    dramas = Rails.cache.fetch(Drama::LIST_CACHE_KEY, expires_in: 1.week) { Drama.in_progress_first.load }
 
     render_json(Drama::IndexResource.new(dramas))
   end
 
   def show
-    cache_key = CacheKeyService.get_key(name, "drama")
+    cache_key = CacheKeyService.get_key(name, Drama::CACHE_TYPE)
     drama = Rails.cache.fetch(cache_key, expires_in: 1.year) { Drama.find_by(name:) }
 
     render_error("Drama not found", status: :not_found) and return unless drama
@@ -36,11 +32,6 @@ class Api::V1::DramasController < ApplicationController
   end
 
   private
-
-  def clear_cache
-    cache_keys = [ LIST_CACHE_KEY, CacheKeyService.get_key(name, "drama") ]
-    cache_keys.each { |key| Rails.cache.delete(key) }
-  end
 
   def name = params[:name] || drama_params[:name]
 

--- a/app/models/drama.rb
+++ b/app/models/drama.rb
@@ -1,5 +1,8 @@
 # Drama model with validations for tracking watch progress and metadata
 class Drama < ApplicationRecord
+  LIST_CACHE_KEY = "drama_list"
+  CACHE_TYPE = "drama"
+
   LIMITS = {
     description: 2000,
     country: 50,
@@ -40,6 +43,7 @@ validate: true
   validate :last_watched_episode_valid, :metadata_valid
 
   before_save :update_watch_status
+  after_commit :invalidate_cache, on: %i[create update]
 
   private
 
@@ -59,6 +63,14 @@ validate: true
     else
       self.watch_status = :not_started
     end
+  end
+
+  def invalidate_cache
+    keys = [ LIST_CACHE_KEY, CacheKeyService.get_key(name, CACHE_TYPE) ]
+    if (old_name = name_previously_was)
+      keys << CacheKeyService.get_key(old_name, CACHE_TYPE)
+    end
+    Rails.cache.delete_multi(keys)
   end
 
   def metadata_valid

--- a/app/models/drama.rb
+++ b/app/models/drama.rb
@@ -43,7 +43,7 @@ validate: true
   validate :last_watched_episode_valid, :metadata_valid
 
   before_save :update_watch_status
-  after_commit :invalidate_cache, on: %i[create update]
+  after_commit :invalidate_cache, on: %i[create update destroy]
 
   private
 

--- a/test/controllers/api/v1/dramas_controller_test.rb
+++ b/test/controllers/api/v1/dramas_controller_test.rb
@@ -101,7 +101,7 @@ class Api::V1::DramasControllerTest < ActionDispatch::IntegrationTest
   test "should cache individual drama on show requests" do
     Rails.cache.clear
 
-    assert_not Rails.cache.exist?(CacheKeyService.get_key(@drama.name, "drama"))
+    assert_not Rails.cache.exist?(CacheKeyService.get_key(@drama.name, Drama::CACHE_TYPE))
 
     get api_v1_drama_path(@drama.name)
     assert_response :ok
@@ -112,8 +112,8 @@ class Api::V1::DramasControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should clear cache after drama creation" do
-    Rails.cache.write("drama_list", "cached_data")
-    Rails.cache.write(CacheKeyService.get_key(@drama.name, "drama"), "cached_drama")
+    Rails.cache.write(Drama::LIST_CACHE_KEY, "cached_data")
+    Rails.cache.write(CacheKeyService.get_key(@drama.name, Drama::CACHE_TYPE), "cached_drama")
 
     post api_v1_dramas_path, params: { drama: {
       name: "Cache Clear Test", airing_status: "ongoing", country: "Korea",
@@ -121,21 +121,22 @@ class Api::V1::DramasControllerTest < ActionDispatch::IntegrationTest
     } }
 
     assert_response :created
-    assert_nil(Rails.cache.read("drama_list"))
+    assert_nil(Rails.cache.read(Drama::LIST_CACHE_KEY))
   end
 
   test "should clear cache after drama update" do
-    Rails.cache.write("drama_list", "cached_data")
-    Rails.cache.write(CacheKeyService.get_key(@drama.name, "drama"), "cached_drama")
+    Rails.cache.write(Drama::LIST_CACHE_KEY, "cached_data")
+    Rails.cache.write(CacheKeyService.get_key(@drama.name, Drama::CACHE_TYPE), "cached_drama")
 
     patch api_v1_drama_path(@drama), params: { drama: {
       name: @drama.name, description: "Updated for cache test"
     } }
 
     assert_response :ok
-    assert_nil(Rails.cache.read("drama_list"))
-    assert_nil(Rails.cache.read(CacheKeyService.get_key(@drama.name, "drama")))
+    assert_nil(Rails.cache.read(Drama::LIST_CACHE_KEY))
+    assert_nil(Rails.cache.read(CacheKeyService.get_key(@drama.name, Drama::CACHE_TYPE)))
   end
+
 
   test "should return 404 when updating non-existent drama" do
     # Test that the controller properly handles non-existent drama

--- a/test/controllers/api/v1/dramas_controller_test.rb
+++ b/test/controllers/api/v1/dramas_controller_test.rb
@@ -88,7 +88,7 @@ class Api::V1::DramasControllerTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
 
     # Ensure cache is being used by mocking the fetch behavior
-    assert_not Rails.cache.exist?("drama_list")
+    assert_not Rails.cache.exist?(Drama::LIST_CACHE_KEY)
 
     get api_v1_dramas_path
     assert_response :ok
@@ -136,7 +136,6 @@ class Api::V1::DramasControllerTest < ActionDispatch::IntegrationTest
     assert_nil(Rails.cache.read(Drama::LIST_CACHE_KEY))
     assert_nil(Rails.cache.read(CacheKeyService.get_key(@drama.name, Drama::CACHE_TYPE)))
   end
-
 
   test "should return 404 when updating non-existent drama" do
     # Test that the controller properly handles non-existent drama


### PR DESCRIPTION
- **refactor: move cache invalidation logic from controller to Drama model**
- **refactor: remove cache invalidation responsibility from DramasController**
- **test: update cache tests to use Drama model constants**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cache handling centralized at the data layer: list and item caches are now invalidated reliably on create/update/delete and use shared cache-key configuration.

* **Tests**
  * Updated tests to use the shared cache-key configuration and reflect new cache invalidation behavior.

* **Chores**
  * Added an explicit runtime library dependency and enabled CI debug logging for setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->