### PR TITLE
fix: drop benchmark gem dependency from bin/measure_memory

### DIFF
--- a/bin/measure_memory
+++ b/bin/measure_memory
@@ -6,15 +6,15 @@
 #
 # Usage: RAILS_ENV=development bundle exec ruby bin/measure_memory
 
-require "benchmark"
-
 ENV["RAILS_ENV"] ||= "development"
 
 rss_before = `ps -o rss= -p #{Process.pid}`.strip.to_i
 
-time = Benchmark.realtime do
-  require_relative "../config/environment"
-end
+# Use a monotonic clock instead of the `benchmark` gem, which Ruby 4.0 dropped
+# from the default gems and which this app does not otherwise depend on.
+started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+require_relative "../config/environment"
+time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
 
 # Force a GC to get stable readings
 GC.start(full_mark: true, immediate_sweep: true)


### PR DESCRIPTION
## What

`bin/measure_memory` fails in a production console with `cannot load such file -- benchmark (LoadError)`.

**Cause:** Ruby 4.0 removed `benchmark` from the default gems. The script was its only consumer, and it was only in the bundle transitively via `typelizer`. #197 moved typelizer to the `development` group, so with `BUNDLE_WITHOUT="development:test"` the gem is absent from the production slug — the script's `require "benchmark"` then fails.

**Scope:** this affects *only* the measurement script. The application never uses `Benchmark` (verified), so the running app is unaffected.

**Fix:** rather than add a gem solely for this dev tool, replace its single `Benchmark.realtime` call with `Process.clock_gettime(Process::CLOCK_MONOTONIC)`. No production dependency added, identical output.

## Verification
- `BUNDLE_WITHOUT="development:test" RAILS_ENV=production bundle exec ruby bin/measure_memory`: ✅ runs, RSS 92.5 MB, boot 0.69s.